### PR TITLE
fix: incorrect generation of dashed parameters

### DIFF
--- a/python_client_generator/generate_apis.py
+++ b/python_client_generator/generate_apis.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import chevron
 
-from .utils import resolve_type, sanitize_name, serialize_to_python_code
+from .utils import resolve_type, sanitize_name, serialize_to_python_code, to_python_name
 
 
 dir_path = Path(os.path.dirname(os.path.realpath(__file__)))
@@ -83,7 +83,7 @@ def get_function_args(method: Dict[str, Any]) -> List[Dict[str, Any]]:
     # Convert params to args format required for templating
     return [
         {
-            "name": p["name"],
+            "name": to_python_name(p["name"]),
             "type": resolve_property_type(p),
             "default": resolve_property_default(p),
             "has_default": resolve_property_default(p) is not None,
@@ -97,7 +97,14 @@ def get_params_by_type(method: Dict[str, Any], type_: str) -> List[Dict[str, str
     :param str type_: `query` or `header`
     """
     params = method.get("parameters", [])
-    return [{"name": p["name"]} for p in params if p["in"] == type_]
+    return [
+        {
+            "name": p["name"],
+            "python_name": to_python_name(p["name"]),
+        }
+        for p in params
+        if p["in"] == type_
+    ]
 
 
 def has_json_body(method: Dict[str, Any]) -> bool:

--- a/python_client_generator/templates/apis.py.mustache
+++ b/python_client_generator/templates/apis.py.mustache
@@ -30,7 +30,7 @@ class {{class_name}}(BaseClient):
         _query_params = { 
 {{/has_query_params}}
 {{#query_params}}
-            "{{name}}": {{name}},
+            "{{name}}": {{python_name}},
 {{/query_params}}
 {{#has_query_params}}
         }
@@ -40,7 +40,7 @@ class {{class_name}}(BaseClient):
         _headers = { 
 {{/has_header_params}}
 {{#header_params}}
-            "{{name}}": {{name}},
+            "{{name}}": {{python_name}},
 {{/header_params}}
 {{#has_header_params}}
         }
@@ -73,7 +73,7 @@ class {{class_name}}(BaseClient):
             _query_params=_query_params, 
 {{/has_query_params}}
 {{#has_header_params}}
-            _headers=_headers, 
+            _headers=_headers,
 {{/has_header_params}}
 {{#has_multipart_data}}
             _multipart_data=_multipart_data,

--- a/python_client_generator/utils.py
+++ b/python_client_generator/utils.py
@@ -49,6 +49,12 @@ def sanitize_name(name: str) -> str:
     return "".join(re.findall(r"[A-Za-z0-9]+[A-Za-z0-9_]*", name))
 
 
+def to_python_name(name: str) -> str:
+    name = name.replace("-", "_")  # Un-dash
+    name = re.sub(r"^\d*", "", name)  # Remove digits fom beginning
+    return name
+
+
 def resolve_type(schema: Dict[str, Any], depth: int = 0, use_literals: bool = False) -> str:
     """
     Resolve Python type for a given schema

--- a/tests/expected/apis.py
+++ b/tests/expected/apis.py
@@ -109,6 +109,7 @@ class Api(BaseClient):
     async def create_foo_api_foo_post(
         self,
         body: Foo,
+        x_custom_header: Optional[str] = "default_value",
         body_serializer_args: Dict[str, Any] = {},
         **kwargs: Any
     ) -> Foo:
@@ -116,9 +117,14 @@ class Api(BaseClient):
         
         """ # noqa 
 
+        _headers = { 
+            "x-custom-header": x_custom_header,
+        }
+
         response = await self._request(
             "POST",
             "/api/foo",
+            _headers=_headers,
             _body=body,
             body_serializer_args=body_serializer_args,
             **kwargs


### PR DESCRIPTION
Fixed generating client for APIs containing dash-separated parameters (like `X-Anything-Header`)