### PR TITLE
fix: generating models with empty or missing `properties` key (#25)

### DIFF
--- a/python_client_generator/generate_models.py
+++ b/python_client_generator/generate_models.py
@@ -96,7 +96,7 @@ def get_references(model: Dict[str, Any]) -> List[str]:
     union_keys = list(set(["allOf", "anyOf", "oneOf"]) & set(model.keys()))
     if union_keys:
         return _get_schema_references(model)
-    else:
+    elif "properties" in model:
         # Must have properties
         for p_schema in model["properties"].values():
             refs += _get_schema_references(p_schema)
@@ -109,7 +109,7 @@ def get_fields(schema: Dict[str, Any]) -> List[Dict[str, Any]]:
     if union_keys:
         # Handle union cases by creating a __root__ defined model
         return [{"name": "__root__", "type": resolve_type(schema)}]
-    else:
+    elif "properties" in schema:
         return [
             {
                 "name": k,
@@ -119,6 +119,8 @@ def get_fields(schema: Dict[str, Any]) -> List[Dict[str, Any]]:
             }
             for k, v in schema["properties"].items()
         ]
+    else:
+        return []
 
 
 def _strip_nonexistant_refs(objects: List[Dict[str, Any]]) -> None:

--- a/tests/expected/fastapi_app_client/models.py
+++ b/tests/expected/fastapi_app_client/models.py
@@ -11,9 +11,14 @@ class FooEnum(str, Enum):
     OPTION_2 = "option_2"
 
 
+class EmptyObject(BaseModel):
+    pass
+
+
 class Bar(BaseModel):
     field_1: str
     field_2: Optional[bool]
+    field_3: Optional[EmptyObject]
 
 
 class Document(BaseModel):

--- a/tests/expected/swagger_petstore_client/models.py
+++ b/tests/expected/swagger_petstore_client/models.py
@@ -64,3 +64,11 @@ class ApiResponse(BaseModel):
     message: Optional[str]
 
 
+class EmptyObjectWithEmptyProperties(BaseModel):
+    pass
+
+
+class EmptyObjectWithNoProperties(BaseModel):
+    pass
+
+

--- a/tests/inputs/fastapi_app.py
+++ b/tests/inputs/fastapi_app.py
@@ -18,9 +18,14 @@ class FooEnum(str, Enum):
     OPTION_2 = "option_2"
 
 
+class EmptyObject(BaseModel):
+    pass
+
+
 class Bar(BaseModel):
     field_1: str
     field_2: Optional[bool]
+    field_3: Optional[EmptyObject]
 
 
 class Foo(BaseModel):

--- a/tests/inputs/swagger-petstore.json
+++ b/tests/inputs/swagger-petstore.json
@@ -1176,6 +1176,13 @@
                 "xml": {
                     "name": "##default"
                 }
+            },
+            "EmptyObjectWithEmptyProperties": {
+                "type": "object",
+                "properties": {}
+            },
+            "EmptyObjectWithNoProperties": {
+                "type": "object"
             }
         },
         "requestBodies": {


### PR DESCRIPTION
Fixes #25