### PR TITLE
fix: do not depend on model declarations

### DIFF
--- a/python_client_generator/templates/models.py.mustache
+++ b/python_client_generator/templates/models.py.mustache
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union

--- a/tests/expected/fastapi_app_client/models.py
+++ b/tests/expected/fastapi_app_client/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union

--- a/tests/expected/swagger_petstore_client/models.py
+++ b/tests/expected/swagger_petstore_client/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union


### PR DESCRIPTION
Added `__future__.annotations` to the `models.py` template to avoid issues with model cross-dependencies and declaration order 